### PR TITLE
Changes to override hashparams for custom requirements

### DIFF
--- a/webroot/js/common/core.utils.js
+++ b/webroot/js/common/core.utils.js
@@ -775,6 +775,17 @@ define([
                $("#page-content").removeClass("dashboard-padding").addClass("dashboard-no-padding");
            }
         }
+        /* It is used to manipulate the hashparams for custom requirements*/
+        this.overrideHashParams = function(hashParams, lastHash){
+            var prevTab = getValueByJsonPath(lastHash,
+                    'q;tab;security-policy-tab', '', false);
+            /* retain selected tab when navigating between
+            global policies and project scoped policies pages */
+            if(prevTab) {
+                hashParams.q = {tab: {'security-policy-tab' : prevTab}};
+            }
+            return hashParams;
+        }
 
         /* Detail Template Generator*/
         this.generateBlockListTemplate = function (config, app, parentConfig) {

--- a/webroot/js/contrail-layout.js
+++ b/webroot/js/contrail-layout.js
@@ -384,6 +384,8 @@ function loadFeature(hashParams) {
     if (JSON.stringify(layoutHandler.getURLHashObj()) != JSON.stringify(hashParams)) {
         globalObj['hashUpdated'] = 1;
     }
+    //Manipulate hash params for custom requirements
+    hashParams = cowu.overrideHashParams(hashParams, lastHash);
     layoutHandler.setURLHashObj(hashParams);
     //Hiding the last updated time and refresh icon on click of an item left menu
     //hideHardRefresh();


### PR DESCRIPTION
    before loading feature

For now using this to retain current tab when
   switching between global and project views under security menu

Change-Id: Icc789e2f01de5e0650bd26a8c7e7e963009724bb